### PR TITLE
Dockerize Miu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.idea
+.git
+.github
+venv
+my_venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,40 @@
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
 
+# Install Python 3 & pip
 RUN apt-get update -qq && \
     apt-get install -y software-properties-common python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
+# Install libindy
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 && \
     add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable" && \
     apt-get update -qq && \
     apt-get install -y libindy && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
+# Optianally set uid & gid at build time
+ARG USER_ID
+ARG GROUP_ID
 
-ADD ./pyserverforindy/requirements.txt /app/pyserverforindy/requirements.txt
-RUN pip install --no-cache-dir -r /app/pyserverforindy/requirements.txt
+# Create unprivileged user & group "app"
+RUN groupadd -g ${GROUP_ID:-1000} app && \
+    useradd -l -u ${USER_ID:-1000} -g app app && \
+    install -d -m 0755 -o app -g app /home/app
 
-ADD . /app
+USER app
 
-CMD python3 /app/pyserverforindy/grpc_server/server.py
+# Install required python libraries
+COPY --chown=app:app ./pyserverforindy/requirements.txt /app/pyserverforindy/requirements.txt
+RUN pip3 install --no-cache-dir -r /app/pyserverforindy/requirements.txt
+
+# Add project files to image
+COPY --chown=app:app . /app
+
+VOLUME /home/app/.indy_client
+
+CMD ["python3", "/app/pyserverforindy/grpc_server/server.py"]
 
 EXPOSE 50051

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -qq && \
+    apt-get install -y software-properties-common python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 && \
+    add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable" && \
+    apt-get update -qq && \
+    apt-get install -y libindy && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
+
+ADD ./pyserverforindy/requirements.txt /app/pyserverforindy/requirements.txt
+RUN pip install --no-cache-dir -r /app/pyserverforindy/requirements.txt
+
+ADD . /app
+
+CMD python3 /app/pyserverforindy/grpc_server/server.py
+
+EXPOSE 50051


### PR DESCRIPTION
Proposed fix for #23.

Based on Ubuntu 18.04 with Python 3 and libindy from official repo.
Features volume to persist pools & wallets and execution from unprivileged user (configurable uid/gid for easier management of files in volumes on docker host).

Example of docker-compose.yaml:
```yaml
version: '3'

services:
  miu:
    build:
      context: .
      dockerfile: Dockerfile
      args:
        USER_ID: 1000
        GROUP_ID: 1000
    image: miu
    volumes:
      - ./data/miu:/home/app/.indy_client
    expose:
      - "50051"
```